### PR TITLE
POST：アイテム（本体）の実装

### DIFF
--- a/src/main/java/com/example/inventory_api/DataInitializer.java
+++ b/src/main/java/com/example/inventory_api/DataInitializer.java
@@ -2,11 +2,10 @@ package com.example.inventory_api;
 
 import com.example.inventory_api.domain.model.Category;
 import com.example.inventory_api.domain.repository.CategoryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 // アプリの起動時に自動で呼び出される
 @Component

--- a/src/main/java/com/example/inventory_api/controller/CategoryController.java
+++ b/src/main/java/com/example/inventory_api/controller/CategoryController.java
@@ -5,12 +5,18 @@ import com.example.inventory_api.controller.dto.CategoryResponse;
 import com.example.inventory_api.controller.dto.CategoryUpdateRequest;
 import com.example.inventory_api.domain.model.Category;
 import com.example.inventory_api.service.CategoryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/categories")

--- a/src/main/java/com/example/inventory_api/controller/ItemController.java
+++ b/src/main/java/com/example/inventory_api/controller/ItemController.java
@@ -1,0 +1,33 @@
+package com.example.inventory_api.controller;
+
+import com.example.inventory_api.controller.dto.ItemCreateRequest;
+import com.example.inventory_api.controller.dto.ItemResponse;
+import com.example.inventory_api.domain.model.Item;
+import com.example.inventory_api.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/items")
+@RequiredArgsConstructor
+public class ItemController {
+
+  private final ItemService itemService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public ItemResponse createItem(@RequestBody @Validated ItemCreateRequest request) {
+    // TODO: 認証機能実装後、実際のuserIdに置き換える
+    String currentUserId = "user1";
+
+    Item createdItem = itemService.createItem(request, currentUserId);
+
+    return new ItemResponse(createdItem);
+  }
+}

--- a/src/main/java/com/example/inventory_api/controller/advice/CustomExceptionHandler.java
+++ b/src/main/java/com/example/inventory_api/controller/advice/CustomExceptionHandler.java
@@ -18,6 +18,7 @@ public class CustomExceptionHandler {
   private static final String LIMIT_PREFIX = "LIMIT:";
   private static final String NOT_FOUND_PREFIX = "NOT_FOUND:";
   private static final String FORBIDDEN_PREFIX = "FORBIDDEN:";
+  private static final String CONFLICT_PREFIX = "CONFLICT:";
 
   // エラーメッセージを定数化
   private static final String MSG_VALIDATION_ERROR = "不正なリクエストです";
@@ -28,6 +29,7 @@ public class CustomExceptionHandler {
   // DTOのバリデーションメッセージに含まれる部分文字列
   private static final String PARTIAL_MSG_REQUIRED = "必須です";
   private static final String PARTIAL_MSG_TOO_LONG = "50文字以内で入力してください";
+  private static final String PARTIAL_MSG_QUANTITY = "0以上の整数";
 
   // 404 Not Found
   @ExceptionHandler(NoHandlerFoundException.class)
@@ -44,65 +46,113 @@ public class CustomExceptionHandler {
     FieldError fieldError = e.getBindingResult().getFieldError();
 
     if (fieldError == null) {
-      ErrorResponse errorResponse = new ErrorResponse("VALIDATION_ERROR", MSG_VALIDATION_ERROR);
-      return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+      return new ResponseEntity<>(
+          new ErrorResponse("VALIDATION_ERROR", MSG_VALIDATION_ERROR),
+          HttpStatus.BAD_REQUEST
+      );
     }
 
-    String errorMessage = fieldError.getDefaultMessage();
-    String errorCode;
+    String fieldName = fieldError.getField();
+    String defaultMessage = fieldError.getDefaultMessage();
+    String errorCode = "VALIDATION_ERROR";
 
-    // エラーメッセージの内容に応じて、API仕様書のエラーコードを判定
-    if (errorMessage != null) {
-      if (errorMessage.contains(PARTIAL_MSG_REQUIRED)) {
-        errorCode = "CATEGORY_NAME_REQUIRED";
-      } else if (errorMessage.contains(PARTIAL_MSG_TOO_LONG)) {
-        errorCode = "CATEGORY_NAME_TOO_LONG";
-      } else {
-        errorCode = "VALIDATION_ERROR";
-      }
-    } else {
-      errorCode = "VALIDATION_ERROR";
+    switch (fieldName) {
+      case "categoryId":
+      case "name":
+        if (defaultMessage != null && defaultMessage.contains(PARTIAL_MSG_REQUIRED)) {
+          errorCode = "ITEM_FIELDS_REQUIRED";
+        } else if (defaultMessage != null && defaultMessage.contains(PARTIAL_MSG_TOO_LONG)) {
+          errorCode = "ITEM_NAME_TOO_LONG";
+        }
+        break;
+      case "quantity":
+        if (defaultMessage != null && defaultMessage.contains(PARTIAL_MSG_QUANTITY)) {
+          errorCode = "INVALID_ITEM_QUANTITY";
+        }
+        break;
+      default:
+        // ★★★ ここの判定を修正しました ★★★
+        if (defaultMessage != null) {
+          if (defaultMessage.contains(PARTIAL_MSG_REQUIRED)) {
+            errorCode = "CATEGORY_NAME_REQUIRED";
+          } else if (defaultMessage.contains(PARTIAL_MSG_TOO_LONG)) {
+            errorCode = "CATEGORY_NAME_TOO_LONG";
+          }
+        }
+        break;
     }
 
-    ErrorResponse errorResponse = new ErrorResponse(errorCode, errorMessage);
+    ErrorResponse errorResponse = new ErrorResponse(errorCode, defaultMessage);
     return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
   }
 
-  // 400 or 409: Service層で発生したエラーをハンドリング
+  // Service層で発生したエラーをハンドリング
   @ExceptionHandler(IllegalStateException.class)
   public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
     String message = e.getMessage();
+
+    if (message.startsWith(CONFLICT_PREFIX)) {
+      return new ResponseEntity<>(
+          new ErrorResponse(
+              "ITEM_NAME_DUPLICATE",
+              message.substring(CONFLICT_PREFIX.length())
+          ),
+          HttpStatus.CONFLICT
+      );
+    }
     if (message.startsWith(DUPLICATE_PREFIX)) {
-      ErrorResponse errorResponse = new ErrorResponse("CATEGORY_NAME_DUPLICATE",
-          message.substring(DUPLICATE_PREFIX.length()));
-      return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT); // 409
+      return new ResponseEntity<>(
+          new ErrorResponse(
+              "CATEGORY_NAME_DUPLICATE",
+              message.substring(DUPLICATE_PREFIX.length())
+          ),
+          HttpStatus.CONFLICT
+      );
     }
     if (message.startsWith(LIMIT_PREFIX)) {
-      ErrorResponse errorResponse = new ErrorResponse("CATEGORY_LIMIT_EXCEEDED",
-          message.substring(LIMIT_PREFIX.length()));
-      return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST); // 400
+      return new ResponseEntity<>(
+          new ErrorResponse(
+              "CATEGORY_LIMIT_EXCEEDED",
+              message.substring(LIMIT_PREFIX.length())
+          ),
+          HttpStatus.BAD_REQUEST
+      );
     }
     if (message.startsWith(NOT_FOUND_PREFIX)) {
-      ErrorResponse errorResponse = new ErrorResponse("NOT_FOUND_ERROR", message.substring(10));
-      return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND); // 404
+      return new ResponseEntity<>(
+          new ErrorResponse(
+              "CATEGORY_NOT_FOUND",
+              message.substring(NOT_FOUND_PREFIX.length())
+          ),
+          HttpStatus.NOT_FOUND
+      );
     }
     if (message.startsWith(FORBIDDEN_PREFIX)) {
-      ErrorResponse errorResponse = new ErrorResponse("DEFAULT_CATEGORY_IMMUTABLE",
-          message.substring(10));
-      return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN); // 403
+      return new ResponseEntity<>(
+          new ErrorResponse(
+              "DEFAULT_CATEGORY_IMMUTABLE",
+              message.substring(FORBIDDEN_PREFIX.length())
+          ),
+          HttpStatus.FORBIDDEN
+      );
     }
 
-    // その他のIllegalStateExceptionは汎用的な400エラーとして返す
-    ErrorResponse errorResponse = new ErrorResponse("BAD_REQUEST", MSG_BAD_REQUEST);
-    return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST); // 400
+    return new ResponseEntity<>(
+        new ErrorResponse(
+            "BAD_REQUEST",
+            MSG_BAD_REQUEST
+        ),
+        HttpStatus.BAD_REQUEST);
   }
 
   // 500 Internal Server Error: 予期せぬエラー全般をハンドリング
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleAllUncaughtException(Exception e) {
-    ErrorResponse errorResponse = new ErrorResponse("INTERNAL_SERVER_ERROR",
-        MSG_INTERNAL_SERVER_ERROR);
-    // 本番環境ではここで詳細なエラーログを出力することが重要
-    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(
+        new ErrorResponse(
+            "INTERNAL_SERVER_ERROR",
+            MSG_INTERNAL_SERVER_ERROR
+        ),
+        HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/main/java/com/example/inventory_api/controller/dto/ItemCreateRequest.java
+++ b/src/main/java/com/example/inventory_api/controller/dto/ItemCreateRequest.java
@@ -1,0 +1,27 @@
+package com.example.inventory_api.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ItemCreateRequest {
+
+  @NotNull(message = "カテゴリIDは必須です")
+  private Integer categoryId;
+
+  @Pattern(regexp = ".*[^\\s　].*", message = "アイテム名は必須です")
+  @NotBlank(message = "アイテム名は必須です")
+  @Size(max = 50, message = "アイテム名は50文字以内で入力してください")
+  private String name;
+
+  @Min(value = 0, message = "数量は0以上の整数で入力してください")
+  private Integer quantity = 0;
+
+  private Integer amount;
+
+  private String place;
+}

--- a/src/main/java/com/example/inventory_api/controller/dto/ItemResponse.java
+++ b/src/main/java/com/example/inventory_api/controller/dto/ItemResponse.java
@@ -1,0 +1,24 @@
+package com.example.inventory_api.controller.dto;
+
+import com.example.inventory_api.domain.model.Item;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemResponse {
+
+  private Integer id;
+  private Integer categoryId;
+  private String name;
+  private Integer quantity;
+
+  public ItemResponse(Item item) {
+    this.id = item.getId();
+    this.categoryId = item.getCategoryId();
+    this.name = item.getName();
+    this.quantity = item.getQuantity();
+  }
+}

--- a/src/main/java/com/example/inventory_api/domain/model/Category.java
+++ b/src/main/java/com/example/inventory_api/domain/model/Category.java
@@ -1,6 +1,10 @@
 package com.example.inventory_api.domain.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/inventory_api/domain/model/Item.java
+++ b/src/main/java/com/example/inventory_api/domain/model/Item.java
@@ -1,13 +1,21 @@
 package com.example.inventory_api.domain.model;
 
-import jakarta.persistence.*;
-import lombok.Data;
-
+import com.example.inventory_api.controller.dto.ItemCreateRequest;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Entity
 @Table(name = "items")
+@NoArgsConstructor
+@AllArgsConstructor
 public class Item {
 
   @Id
@@ -22,7 +30,7 @@ public class Item {
 
   private Integer quantity;
 
-  private Integer price;
+  private Integer amount;
 
   private String place;
 
@@ -30,4 +38,14 @@ public class Item {
 
   private LocalDateTime created;
 
+  public Item(ItemCreateRequest request, String userId) {
+    this.categoryId = request.getCategoryId();
+    this.userId = userId;
+    this.name = request.getName();
+    this.quantity = request.getQuantity();
+    this.amount = request.getAmount();
+    this.place = request.getPlace();
+    this.deleted = false;
+    this.created = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/example/inventory_api/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/example/inventory_api/domain/repository/CategoryRepository.java
@@ -1,11 +1,10 @@
 package com.example.inventory_api.domain.repository;
 
 import com.example.inventory_api.domain.model.Category;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 // Categoryエンティティとやり取りを行うリポジトリ（インターフェース）
 public interface CategoryRepository extends JpaRepository<Category, Integer> {

--- a/src/main/java/com/example/inventory_api/domain/repository/ItemRepository.java
+++ b/src/main/java/com/example/inventory_api/domain/repository/ItemRepository.java
@@ -1,8 +1,29 @@
 package com.example.inventory_api.domain.repository;
 
 import com.example.inventory_api.domain.model.Item;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Integer> {
 
+  /**
+   * 指定したカテゴリIDとユーザーIDに紐づく、未削除のアイテムをすべて取得
+   *
+   * @param categoryId 検索対象のカテゴリID
+   * @param userId     検索対象のユーザーID
+   * @return 条件に一致する未削除のアイテムのリスト
+   */
+  @Query(value = """
+      SELECT *
+      FROM items
+      WHERE category_id = :categoryId
+      AND user_id = :userId
+      AND deleted = false
+      """, nativeQuery = true)
+  List<Item> findUserCategoryItems(
+      @Param("categoryId") Integer categoryId,
+      @Param("userId") String userId
+  );
 }

--- a/src/main/java/com/example/inventory_api/service/CategoryService.java
+++ b/src/main/java/com/example/inventory_api/service/CategoryService.java
@@ -8,14 +8,13 @@ import com.example.inventory_api.domain.repository.CategoryRepository;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ULocale;
 import jakarta.transaction.Transactional;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/inventory_api/service/ItemService.java
+++ b/src/main/java/com/example/inventory_api/service/ItemService.java
@@ -1,0 +1,71 @@
+package com.example.inventory_api.service;
+
+import com.example.inventory_api.controller.dto.ItemCreateRequest;
+import com.example.inventory_api.domain.model.Category;
+import com.example.inventory_api.domain.model.Item;
+import com.example.inventory_api.domain.repository.CategoryRepository;
+import com.example.inventory_api.domain.repository.ItemRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+  private final ItemRepository itemRepository;
+  private final CategoryRepository categoryRepository;
+
+  private static final String SYSTEM_USER_ID = "system";
+
+  // エラーメッセージ
+  private static final String MSG_CATEGORY_NOT_FOUND = "NOT_FOUND:指定されたカテゴリは見つかりません";
+  private static final String MSG_DUPLICATE = "CONFLICT:そのアイテム名は既に登録されています";
+  private static final String MSG_DB_ACCESS_ERROR = "データベースへのアクセスに失敗しました";
+  private static final String MSG_UNEXPECTED_ERROR = "予期せぬエラーが発生しました";
+
+  /**
+   * 新しいアイテムを1件登録 createItem
+   */
+  @Transactional
+  public Item createItem(
+      ItemCreateRequest request,
+      String userId
+  ) {
+    try {
+      // 指定したIDでカテゴリを取得
+      Category category = categoryRepository.findById(request.getCategoryId())
+          .orElseThrow(() -> new IllegalStateException(MSG_CATEGORY_NOT_FOUND));
+
+      // カテゴリの権限チェック
+      if (!category.getUserId().equals(userId) && !category.getUserId().equals(SYSTEM_USER_ID)) {
+        throw new IllegalStateException(MSG_CATEGORY_NOT_FOUND);
+      }
+
+      // カテゴリ内の既存アイテムを全て取得
+      List<Item> existingItems = itemRepository.findUserCategoryItems(
+          request.getCategoryId(),
+          userId
+      );
+
+      // アイテム名の重複チェック
+      boolean isDuplicate = existingItems.stream()
+          .anyMatch(item -> item.getName().equals(request.getName()));
+      if (isDuplicate) {
+        throw new IllegalStateException(MSG_DUPLICATE);
+      }
+
+      Item newItem = new Item(request, userId);
+      return itemRepository.save(newItem);
+
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (DataAccessException e) {
+      throw new RuntimeException(MSG_DB_ACCESS_ERROR, e);
+    } catch (Exception e) {
+      throw new RuntimeException(MSG_UNEXPECTED_ERROR, e);
+    }
+  }
+}

--- a/src/test/java/com/example/inventory_api/controller/CategoryControllerTest.java
+++ b/src/test/java/com/example/inventory_api/controller/CategoryControllerTest.java
@@ -1,5 +1,17 @@
 package com.example.inventory_api.controller;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.example.inventory_api.controller.advice.CustomExceptionHandler;
 import com.example.inventory_api.controller.dto.CategoryCreateRequest;
 import com.example.inventory_api.controller.dto.CategoryResponse;
@@ -7,23 +19,14 @@ import com.example.inventory_api.controller.dto.CategoryUpdateRequest;
 import com.example.inventory_api.domain.model.Category;
 import com.example.inventory_api.service.CategoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({CategoryController.class, CustomExceptionHandler.class})
 public class CategoryControllerTest {

--- a/src/test/java/com/example/inventory_api/domain/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/example/inventory_api/domain/repository/CategoryRepositoryTest.java
@@ -1,13 +1,12 @@
 package com.example.inventory_api.domain.repository;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
 import com.example.inventory_api.domain.model.Category;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @DataJpaTest
 public class CategoryRepositoryTest {

--- a/src/test/java/com/example/inventory_api/service/CategoryServiceTest.java
+++ b/src/test/java/com/example/inventory_api/service/CategoryServiceTest.java
@@ -1,10 +1,23 @@
 package com.example.inventory_api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.example.inventory_api.controller.dto.CategoryCreateRequest;
 import com.example.inventory_api.controller.dto.CategoryResponse;
 import com.example.inventory_api.controller.dto.CategoryUpdateRequest;
 import com.example.inventory_api.domain.model.Category;
 import com.example.inventory_api.domain.repository.CategoryRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,16 +26,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CategoryServiceTest {


### PR DESCRIPTION
# 概要
POST：アイテム（本体）の実装

## 作業内容
- `POST: /items`を実装

## 動作確認　
  - **正常系**
    - 存在するカテゴリ、アイテム名50文字以内、在庫数に0以上の整数でアイテムを作成できる。
    [![Image from Gyazo](https://i.gyazo.com/f92410f74d46ae5bdd598d1bd4ac9351.png)](https://gyazo.com/f92410f74d46ae5bdd598d1bd4ac9351)
    在庫数0も可
    [![Image from Gyazo](https://i.gyazo.com/670e37fb5d188353c9168e50fd6ff5ef.png)](https://gyazo.com/670e37fb5d188353c9168e50fd6ff5ef)

  - **異常系**
    - カテゴリidを未指定：400エラー
      [![Image from Gyazo](https://i.gyazo.com/aa7cd63878b3b8de461bba988b91b59d.png)](https://gyazo.com/aa7cd63878b3b8de461bba988b91b59d)
    - 存在しないカテゴリのidを指定：400エラー
      [![Image from Gyazo](https://i.gyazo.com/36562c5323df3a56dc3968bd8bb5c2b3.png)](https://gyazo.com/36562c5323df3a56dc3968bd8bb5c2b3)
    -  カテゴリ名を未指定：400エラー
      [![Image from Gyazo](https://i.gyazo.com/0c81902a4aa5c2abda74a3883ade71f6.png)](https://gyazo.com/0c81902a4aa5c2abda74a3883ade71f6)
    - カテゴリ名に全角スペースを指定：400エラー
      [![Image from Gyazo](https://i.gyazo.com/4204c077bebd2599beadf4d0830f0a97.png)](https://gyazo.com/4204c077bebd2599beadf4d0830f0a97)
    - カテゴリ名に50文字以上を入力：400エラー
      [![Image from Gyazo](https://i.gyazo.com/d81d10e03278869795ce881e724ea426.png)](https://gyazo.com/d81d10e03278869795ce881e724ea426)
    - 在庫数に負の数を入力：400エラー
      [![Image from Gyazo](https://i.gyazo.com/ce98bee1f5770b13c292f737f9f249ef.png)](https://gyazo.com/ce98bee1f5770b13c292f737f9f249ef)
    - 同一カテゴリ内で同じアイテム名を指定：409エラー
      [![Image from Gyazo](https://i.gyazo.com/0dc2da1e5ddfc7fa5bca49b89a5057a9.png)](https://gyazo.com/0dc2da1e5ddfc7fa5bca49b89a5057a9)
  
# 備考
テストについては、この作業ブランチのLGTMを頂け次第、
テスト用のブランチを作成してテストを行う

# 関連Issue
- #29 